### PR TITLE
Integrate chirp codec with Acoustic Data Sync

### DIFF
--- a/chirp.js
+++ b/chirp.js
@@ -18,6 +18,8 @@ class ChirpEmitter {
     }
 
     async transmit(text) {
+        // Ensure AudioContext is resumed for cross-browser support
+        await ChirpCodec.ensureAudioContextReady(this.ctx);
         // Use chirp codec from solst-ice/chirp
         await ChirpCodec.encodeText(text, this.ctx);
     }
@@ -32,7 +34,9 @@ class ChirpReceiver {
 
     async start() {
         try {
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            await ChirpCodec.ensureAudioContextReady(this.ctx);
+            const getUserMedia = navigator.mediaDevices?.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+            const stream = await (getUserMedia.call(navigator.mediaDevices || navigator, { audio: true }));
             const source = this.ctx.createMediaStreamSource(stream);
             source.connect(this.analyser);
             this.listen();

--- a/index.html
+++ b/index.html
@@ -1122,12 +1122,13 @@ table {
         }
 
         function emitChirp() {
-            fractalEmitter.transmitFractal(document.getElementById('chirp-message').value);
+            chirpEmitter.transmit(document.getElementById('chirp-message').value);
             document.getElementById('status').textContent = '🎶 Chirp Sent';
         }
 
         function startChirpListen() {
-            fractalReceiver.start();
+            ChirpCodec.resetDecoder();
+            chirpReceiver.start();
             document.getElementById('status').textContent = '🎧 Listening for Chirps';
         }
 

--- a/stellar-bridge.html
+++ b/stellar-bridge.html
@@ -344,12 +344,13 @@ function visualizeSequence() {
 }
 
 function emitChirpSB() {
-    fractalEmitter.transmitFractal(document.getElementById('chirp-msg').value);
+    chirpEmitter.transmit(document.getElementById('chirp-msg').value);
     document.getElementById('status').innerHTML = '<div>STATUS: Chirp Sent</div>';
 }
 
 function startListenSB() {
-    fractalReceiver.start();
+    ChirpCodec.resetDecoder();
+    chirpReceiver.start();
     document.getElementById('status').innerHTML = '<div>STATUS: Listening</div>';
 }
 </script>


### PR DESCRIPTION
## Summary
- hook chirpEmitter and chirpReceiver into the Acoustic Data Sync UI
- ensure audio context ready in `chirp.js`
- call chirp codec when emitting and listening
- update Stellar Bridge helper page to use chirp emitter/receiver

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684704d7f070832ba02546520532429d