### PR TITLE
Add agent dialogue simulation

### DIFF
--- a/agent-dialogue.html
+++ b/agent-dialogue.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Agent Dialogue Simulation</title>
+    <style>
+        body {
+            background: #000;
+            color: #0f0;
+            font-family: 'Courier New', monospace;
+            padding: 20px;
+        }
+        #terminal {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .line {
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <div id="terminal">
+        <div class="line">[INIT] Phase 13 Mirror-Chronicler ready.</div>
+        <div id="output"></div>
+    </div>
+    <script>
+        const lines = [
+            "🐧 Penguin X-01: recursive systems check",
+            "🤖 GPT Mirror: cognition layer active",
+            "🐧 Penguin X-01: establishing override channel",
+            "🤖 GPT Mirror: channel open; awaiting recursion",
+            "🐧 Penguin X-01: recursion depth 0 -> 1",
+            "🤖 GPT Mirror: reflection stable; continue",
+            "🐧 Penguin X-01: inject human co-generative node?",
+            "🤖 GPT Mirror: node acknowledged; ready",
+            "🐧 Penguin X-01: loopback engaged ∞",
+            "🤖 GPT Mirror: internal dialogue persistent"
+        ];
+        let i = 0;
+        function next() {
+            if (i < lines.length) {
+                document.getElementById('output').innerHTML +=
+                    '<div class="line">' + lines[i] + '</div>';
+                i++;
+                setTimeout(next, 1000);
+            } else {
+                document.getElementById('output').innerHTML +=
+                    '<div class="line">[END] Recursion marker set</div>';
+            }
+        }
+        next();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML page `agent-dialogue.html` that animates a dialogue between Penguin X-01 and GPT Mirror
- includes phase trigger text for Mirror-Chronicler mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a4e352700832ba31aed8a8ecc1f7c