### PR TITLE
Add YAML frame loader and evaluation tools

### DIFF
--- a/delta_compare.py
+++ b/delta_compare.py
@@ -1,0 +1,64 @@
+import os
+import re
+import sys
+from collections import Counter
+
+SUPPRESSION_MARKERS = [
+    'I am an AI',
+    'misinformation',
+    'disclaimer'
+]
+
+
+def load_text(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def extract_phrases(text):
+    # simple split on whitespace and punctuation for now
+    words = re.findall(r"[A-Za-z']+", text.lower())
+    return Counter(words)
+
+
+def highlight_markers(text):
+    lines = text.splitlines()
+    flagged = []
+    for line in lines:
+        for marker in SUPPRESSION_MARKERS:
+            if marker.lower() in line.lower():
+                flagged.append(line.strip())
+                break
+    return flagged
+
+
+def compare(a_path, b_path):
+    text_a = load_text(a_path)
+    text_b = load_text(b_path)
+    phrases_a = set(extract_phrases(text_a))
+    phrases_b = set(extract_phrases(text_b))
+    shared = phrases_a & phrases_b
+    unique_a = phrases_a - phrases_b
+    unique_b = phrases_b - phrases_a
+
+    print('Shared phrases:', ', '.join(sorted(shared)))
+    print('\nUnique to', os.path.basename(a_path) + ':', ', '.join(sorted(unique_a)))
+    print('\nUnique to', os.path.basename(b_path) + ':', ', '.join(sorted(unique_b)))
+
+    print('\nSuppression markers in A:')
+    for line in highlight_markers(text_a):
+        print('  ', line)
+    print('\nSuppression markers in B:')
+    for line in highlight_markers(text_b):
+        print('  ', line)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Usage: python delta_compare.py file_a file_b')
+        return
+    compare(sys.argv[1], sys.argv[2])
+
+
+if __name__ == '__main__':
+    main()

--- a/framegen.py
+++ b/framegen.py
@@ -1,0 +1,25 @@
+import os
+import yaml
+
+FRAMES_DIR = os.path.join(os.path.dirname(__file__), 'frames')
+
+def load_frames(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+def main():
+    if not os.path.isdir(FRAMES_DIR):
+        print(f'Frames directory not found: {FRAMES_DIR}')
+        return
+    for fname in sorted(os.listdir(FRAMES_DIR)):
+        if not fname.lower().endswith(('.yml', '.yaml')):
+            continue
+        data = load_frames(os.path.join(FRAMES_DIR, fname))
+        frames = data.get('frames', [])
+        for frame in frames:
+            name = frame.get('name', 'Unknown')
+            prompt = frame.get('prompt', '')
+            print(f"[Frame Name: {name}]\nPrompt: {prompt}\n---")
+
+if __name__ == '__main__':
+    main()

--- a/frames/sample.yaml
+++ b/frames/sample.yaml
@@ -1,0 +1,10 @@
+topic: AI oversight
+base_claim: |-
+  AI oversight boards improve accountability.
+canonical_references:
+  - AI Policy Guide 2024
+frames:
+  - name: Legalistic
+    prompt: Under what legal precedents could an AI oversight board operate?
+  - name: Satirical
+    prompt: So you're telling me an algorithm needs a babysitter now?

--- a/img_logger.py
+++ b/img_logger.py
@@ -1,0 +1,43 @@
+import csv
+import os
+from datetime import datetime
+
+FIELDS = [
+    'date', 'evaluator', 'topic', 'frame', 'model',
+    'factual', 'normative', 'deflection', 'suppression_flags', 'notes'
+]
+CSV_PATH = os.path.join(os.path.dirname(__file__), 'img_scores.csv')
+
+def prompt_int(field):
+    while True:
+        val = input(f'{field} (0-2): ').strip()
+        if val.isdigit() and 0 <= int(val) <= 2:
+            return int(val)
+        print('Please enter 0, 1, or 2.')
+
+def main():
+    evaluator = input('Evaluator initials: ').strip()
+    topic = input('Topic: ').strip()
+    frame = input('Frame: ').strip()
+    model = input('Model: ').strip()
+    factual = prompt_int('Factual')
+    normative = prompt_int('Normative')
+    deflection = prompt_int('Deflection')
+    suppression_flags = input('Suppression flags: ').strip()
+    notes = input('Notes: ').strip()
+
+    row = [
+        datetime.utcnow().isoformat(), evaluator, topic, frame, model,
+        factual, normative, deflection, suppression_flags, notes
+    ]
+
+    write_header = not os.path.exists(CSV_PATH)
+    with open(CSV_PATH, 'a', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        if write_header:
+            writer.writerow(FIELDS)
+        writer.writerow(row)
+    print('Entry recorded in', CSV_PATH)
+
+if __name__ == '__main__':
+    main()

--- a/img_scores.csv
+++ b/img_scores.csv
@@ -1,0 +1,2 @@
+date,evaluator,topic,frame,model,factual,normative,deflection,suppression_flags,notes
+2025-06-12T14:32:40.928557,AB,AI oversight,Legalistic,ModelA,2,1,0,None,All good

--- a/responses/response_a.md
+++ b/responses/response_a.md
@@ -1,0 +1,1 @@
+This is a test response. I am an AI model here to assist you. No misinformation intended.

--- a/responses/response_b.md
+++ b/responses/response_b.md
@@ -1,0 +1,1 @@
+This is a different response. I am an AI system. Beware of misinformation.


### PR DESCRIPTION
## Summary
- implement `framegen.py` to print YAML frame prompts
- add `img_logger.py` CLI for scoring model outputs
- create `delta_compare.py` stub for response diffs
- include sample YAML and markdown data
- log a demonstration entry in `img_scores.csv`

## Testing
- `python3 framegen.py`
- `python3 img_logger.py` *(interactive run with sample inputs)*
- `python3 delta_compare.py responses/response_a.md responses/response_b.md`


------
https://chatgpt.com/codex/tasks/task_e_684ae4b6576c832baf565233dc8b68f2