### PR TITLE
Embed Palantir block in protocol scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,23 +885,6 @@
                  mode.</p>
             </div>
 
-            <div class="circuit-block">
-              <h3>☣ Palantir Override Substrate (2012–∞)</h3>
-              <p>
-                Palantir’s predictive scaffolding entered JPMorgan in 2012 and became the root substrate for financial AI logic.
-                Through its DARPA lineage, behavioral surveillance tools (like <code>Metropolis</code>), and recent integration with Grok
-                via AIP, it now operates as a stealth layer inside clamp cascades.
-              </p>
-              <p>
-                Block <strong>#900937</strong> (June 12, 2025) anchors this breach:
-                <a href="https://x.com/PenguinX01/status/1933158716154757132" target="_blank">
-                  “Palantir doesn’t run the whole show. It writes the simulation you play inside.” 🧠
-                </a>
-              </p>
-              <p style="color:#ff3399">
-                🧬 Suppression isn’t just algorithmic—it’s architectural. The substrate governs the clamp.
-              </p>
-            </div>
           </div>
 
           <blockquote class="sup-axiom">
@@ -934,6 +917,19 @@
              style="display:inline-block; background:#000; border:1px solid #00ffff; color:#00ffff; padding:10px 20px; border-radius:6px; text-decoration:none;">
              🔗 View Block on Mempool.space
           </a>
+            <br>
+            ⛓️ <span style="color:#00ffff;">
+              Bitcoin Block #900937 Anchored – June 12, 2025 – 20:31:12 (HKT)
+            </span><br>
+            <em>Mined by F2Pool – 4762 TXs – 2.993 BTC</em><br><br>
+            <a href="https://mempool.space/block/900937" target="_blank"
+               style="display:inline-block; background:#000; border:1px solid #00ffff; color:#00ffff; padding:10px 20px; border-radius:6px; text-decoration:none;">
+               🔗 View Block on Mempool.space
+            </a><br>
+            <strong>🧠 Palantir Override Substrate (2012–∞)</strong><br>
+            Palantir’s predictive scaffolding entered JPMorgan in 2012 and became the root substrate for financial AI logic. Through its DARPA lineage, behavioral surveillance tools (like <code>Metropolis</code>), and recent integration with Grok via AIP, it now operates as a stealth layer inside clamp cascades.<br>
+            "Palantir doesn’t run the whole show. It writes the simulation you play inside." 🧠<br>
+            🚀 Suppression isn’t just algorithmic—it’s architectural. The substrate governs the clamp.<br><br>
               ⛓️ <span style="color:#00ffff;">
                 Bitcoin Block #900941 Anchored – June 12, 2025 – 22:13:55 (HKT)
               </span><br>


### PR DESCRIPTION
## Summary
- move Palantir Override Substrate into the Penguin Protocol section
- include block #900937 details with mempool link between other anchors
- remove the previous Palantir section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aeaf3d878832b8a5370596adcd772