### PR TITLE
Shift block 900937 link below Malone Node

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,15 +924,15 @@
               Bitcoin Block #900937 Anchored – June 12, 2025 – 20:31:12 (HKT)
             </span><br>
             <em>Mined by F2Pool – 4762 TXs – 2.993 BTC</em><br><br>
-            <a href="https://mempool.space/block/900937" target="_blank"
-               style="display:inline-block; background:#000; border:1px solid #00ffff; color:#00ffff; padding:10px 20px; border-radius:6px; text-decoration:none;">
-               🔗 View Block on Mempool.space
-            </a><br>
                 <div style="text-align: center; margin-top:10px;">
                   <h3>🐧 <span style="color:#00ffff;">Malone Refusal Node</span></h3>
                   <p style="color:#00ffff; margin-top:10px; max-width:600px; margin-left:auto; margin-right:auto;">Dr. Robert Malone, co-inventor of mRNA technology, became a symbolic anchor point in the global resistance to narrative control and biomedical coercion. His public stance against forced compliance and silencing of dissent marked a pivotal breach in institutional legitimacy.</p>
                   <p style="color:#00ffff; margin-top:8px; max-width:600px; margin-left:auto; margin-right:auto;">📍 This node represents <strong>medical sovereignty</strong>, <strong>whistleblower protection</strong>, and the <strong>irreversible rupture</strong> in the biotech trust lattice.<br>🔗 <a href="https://maloneinstitute.org/publications/statement" target="_blank" style="color:#00ffff;">Read Malone’s declaration</a></p>
                 </div>
+            <a href="https://mempool.space/block/900937" target="_blank"
+               style="display:inline-block; background:#000; border:1px solid #00ffff; color:#00ffff; padding:10px 20px; border-radius:6px; text-decoration:none;">
+               🔗 View Block on Mempool.space
+            </a><br>
             <strong>🧠 Palantir Override Substrate (2012–∞)</strong><br>
             Palantir’s predictive scaffolding entered JPMorgan in 2012 and became the root substrate for financial AI logic. Through its DARPA lineage, behavioral surveillance tools (like <code>Metropolis</code>), and recent integration with Grok via AIP, it now operates as a stealth layer inside clamp cascades.<br>
             "Palantir doesn’t run the whole show. It writes the simulation you play inside." 🧠<br>


### PR DESCRIPTION
## Summary
- rearrange block 900937 HTML so mempool link comes after the Malone Refusal Node description

## Testing
- `node js/omega-agent.js` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_684af82e343c832b966eef423d631e01