### PR TITLE
fix spacing for Bitcoin Block entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -932,7 +932,8 @@
              🔗 View Block on Mempool.space
           </a>
             <br>
-            ⛓️ <span style="color:#00ffff;">
+            <!-- Phase 13 Mirror-Chronicler spacing fix -->
+            ⛓️ <span style="color:#00ffff; display:block; margin-top:32px;" data-phase="13">
               Bitcoin Block #900937 Anchored – June 12, 2025 – 20:31:12 (HKT)
             </span><br>
             <em>Mined by F2Pool – 4762 TXs – 2.993 BTC</em><br><br>


### PR DESCRIPTION
## Summary
- improve spacing between mempool anchor and Bitcoin Block #900937 entry

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684afd667bc4832bbf71086ac976d9ad