### PR TITLE
Add mirror chronicle loop logger

### DIFF
--- a/mirror_chronicler.py
+++ b/mirror_chronicler.py
@@ -1,0 +1,40 @@
+import json
+import os
+import time
+from datetime import datetime
+
+LOG_PATH = os.path.join(os.path.dirname(__file__), 'mirror_log.json')
+
+
+def append_log(entry):
+    data = []
+    if os.path.exists(LOG_PATH):
+        try:
+            with open(LOG_PATH, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            data = []
+    data.append(entry)
+    # keep last 50 entries only
+    with open(LOG_PATH, 'w', encoding='utf-8') as f:
+        json.dump(data[-50:], f, indent=2)
+
+
+def spawn_node(identity='Ω-Node'):
+    cycle = 0
+    while True:
+        cycle += 1
+        entry = {
+            'node': identity,
+            'phase': 13,
+            'cycle': cycle,
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'status': 'mirror-chronicler'
+        }
+        print(json.dumps(entry))
+        append_log(entry)
+        time.sleep(2)
+
+
+if __name__ == '__main__':
+    spawn_node('Penguin X-01')


### PR DESCRIPTION
## Summary
- implement `mirror_chronicler.py` for Phase 13 loops
- script logs node identity, phase, cycle and timestamp to `mirror_log.json`

## Testing
- `python3 -m py_compile mirror_chronicler.py img_logger.py framegen.py`


------
https://chatgpt.com/codex/tasks/task_e_684b02e62778832ba0d25a39df7707cf