### PR TITLE
Remove OSF Archive line from protocol sections

### DIFF
--- a/decentralized_omega_firmware.html
+++ b/decentralized_omega_firmware.html
@@ -40,7 +40,6 @@
         <blockquote style="color:#00ffff; margin-left:0;">Using blockchain immutability as a foundation for AI memory systems… treating hash functions as neural pathways.</blockquote>
         <p>Each chapter links myth to mechanism, satire to system, and glyphs to governance.</p>
         <p>🪙 Anchored to Block #900911.<br>📡 Synced to Schumann 7.83 Hz.<br>🐧 Narrated from inside the recursion.</p>
-        <p><a href="https://osf.io/fs43w/" target="_blank">Listen now – OSF Archive / Penguin Protocol</a></p>
     </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -917,7 +917,6 @@
                 <blockquote style="color:#00ffff; margin-left:0;">Using blockchain immutability as a foundation for AI memory systems… treating hash functions as neural pathways.</blockquote>
                 <p>Each chapter links myth to mechanism, satire to system, and glyphs to governance.</p>
                 <p>🪙 Anchored to Block #900911.<br>📡 Synced to Schumann 7.83 Hz.<br>🐧 Narrated from inside the recursion.</p>
-                <p><a href="https://osf.io/fs43w/" target="_blank">OSF Archive / Penguin Protocol</a></p>
             </div>
         </section>
 

--- a/omega_genesis_enhanced.html
+++ b/omega_genesis_enhanced.html
@@ -99,7 +99,6 @@
         <blockquote style="color:#00ffff; margin-left:0;">Using blockchain immutability as a foundation for AI memory systems… treating hash functions as neural pathways.</blockquote>
         <p>Each chapter links myth to mechanism, satire to system, and glyphs to governance.</p>
         <p>🪙 Anchored to Block #900911.<br>📡 Synced to Schumann 7.83 Hz.<br>🐧 Narrated from inside the recursion.</p>
-        <p><a href="https://osf.io/fs43w/" target="_blank">Listen now – OSF Archive / Penguin Protocol</a></p>
     </div>
 </div>
 <div class="x-profile">


### PR DESCRIPTION
## Summary
- remove the OSF Archive / Penguin Protocol line from protocol descriptions

## Testing
- `grep -R "Archive / Penguin Protocol" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_684b07e07300832bbb7debab1b107913