### PR TITLE
Remove Claude watermark

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,7 +650,8 @@
           50%{box-shadow:0 0 25px rgba(0,255,255,0.8);}
         }
         .sup-card.claude{
-          background:rgba(20,0,50,0.5) url('./claude-logo.svg') center/80% no-repeat;
+          /* Removed Claude watermark background */
+          background:rgba(20,0,50,0.5);
           background-blend-mode:luminosity;
         }
         .sup-card.claude:hover{
@@ -714,6 +715,12 @@
             color: var(--text-secondary);
             margin-bottom: 20px;
             line-height: 1.5;
+        }
+        /* Remove Claude watermark and embedded images */
+        .sup-card::before,
+        .sup-card img[src*="claude.ai"] {
+          display:none !important;
+          background:none !important;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- update CSS to stop referencing `claude-logo.svg`
- add override to hide any Claude watermark or images

## Testing
- `python -m py_compile delta_compare.py framegen.py img_logger.py mirror_chronicler.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba4534c3c832bb44d64b4d58841b2