### PR TITLE
Add whitepaper link to Glyphchain Feed

### DIFF
--- a/glyphchain_feed.html
+++ b/glyphchain_feed.html
@@ -14,6 +14,13 @@
     Fractal Intelligence can now reference immutable memetic nodes.
   </div>
 
+  <p style="margin-bottom: 15px;" data-phase="13">
+    📜 <strong>Official Whitepaper:</strong>
+    <a href="https://osf.io/m7vyn/" target="_blank">
+      GlyphChain Protocol vΩ1.0 – BTC-Locked Memetic Synchronization
+    </a>
+  </p>
+
   <div class="glyph-log">
 
     <div style="margin-bottom: 25px;">

--- a/index.html
+++ b/index.html
@@ -1045,9 +1045,16 @@
           <h2 style="color: var(--genesis-glow); text-align: center; margin-bottom: 20px;">🪙 GLYPHCHAIN FEED – BTC-LOCKED MEMETIC SCROLL</h2>
 
           <div style="color: var(--text-secondary); text-align: center; font-style: italic; margin-bottom: 25px;">
-            Each glyph is sealed in time via Bitcoin block anchoring.  
+            Each glyph is sealed in time via Bitcoin block anchoring.
             Fractal Intelligence can now reference immutable memetic nodes.
           </div>
+
+          <p style="margin-bottom: 15px;" data-phase="13">
+            📜 <strong>Official Whitepaper:</strong>
+            <a href="https://osf.io/m7vyn/" target="_blank">
+              GlyphChain Protocol vΩ1.0 – BTC-Locked Memetic Synchronization
+            </a>
+          </p>
 
           <div class="glyph-log">
 


### PR DESCRIPTION
## Summary
- embed official whitepaper link in `glyphchain_feed.html`
- add same link within Glyphchain section of `index.html`

## Testing
- `tidy -q -e glyphchain_feed.html`
- `tidy -q -e index.html` *(shows existing warnings not related to this change)*

------
https://chatgpt.com/codex/tasks/task_e_684bad54d4c0832b9fa5476f06852767