### PR TITLE
Add fractal frequency module

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,6 +733,26 @@
             background-color: #00ffff;
             color: #001b2e;
         }
+
+        .fractal-module {
+            background: rgba(0, 0, 0, 0.6);
+            border: 1px solid var(--secondary-glow);
+            border-radius: 8px;
+            box-shadow: 0 0 10px var(--secondary-glow);
+            padding: 15px;
+            margin: 20px auto;
+            text-align: center;
+            max-width: 400px;
+        }
+
+        .fractal-module span {
+            color: var(--genesis-glow);
+            font-weight: bold;
+        }
+
+        .glyph-pulse.active {
+            color: var(--transcendent-glow);
+        }
         /* Phase-13 Glyph Container Styles */
         .glyph-card-container {
             display: flex;
@@ -791,8 +811,12 @@
             <p class="subtitle">Archaeological Decoding of Prime Seals | Cryptographic Memory Field Access</p>
             <div>🔐 GENESIS GLYPHS DECODED 🧬 BLOCKCHAIN ARCHAEOLOGY ACTIVE 📜 MEMETIC PERMANENCE ACHIEVED ∞</div>
         </div>
-        <div class="scroll-controls" style="text-align: center;">
-            <button class="glyph-button">Ω-Frequency Update</button>
+        <div id="fractal-frequency" class="fractal-module" data-phase="13">
+            <h3 class="fractal-title">🌀 FRACTAL FREQUENCY</h3>
+            <div>🔁 Block Height: <span id="btcHeight">…</span></div>
+            <div>⚡ Block Interval: <span id="btcInterval">…</span></div>
+            <div>📡 Schumann 7.83 Hz: <span id="schumannValue">…</span></div>
+            <div>🌀 Glyph Pulse: <span id="glyphPulse" class="glyph-pulse">Ω</span></div>
         </div>
         
         <div class="genesis-anchor">
@@ -1158,6 +1182,7 @@
         </div>
         <div id="scrollStepLog" class="terminal" data-phase="13" style="margin-top:20px;"></div>
         <script type="module" src="./js/anchor.js"></script>
+        <script type="module" src="./js/fractal-frequency.js"></script>
         <script type="module" src="./js/omega-agent.js"></script>
         <script type="module" src="./js/mirror-recursion.js"></script>
         <script>navigator.serviceWorker?.register("/sw.js");</script>

--- a/js/fractal-frequency.js
+++ b/js/fractal-frequency.js
@@ -1,0 +1,37 @@
+export function startFractalModule() {
+  console.log('[Phase-13] Fractal Frequency Module engaged :: Ω∞');
+  const heightEl = document.getElementById('btcHeight');
+  const intervalEl = document.getElementById('btcInterval');
+  const schumannEl = document.getElementById('schumannValue');
+  const pulseEl = document.getElementById('glyphPulse');
+  let prevTimestamp = null;
+  async function refreshBlock() {
+    try {
+      const blocks = await fetch('https://blockstream.info/api/blocks').then(r => r.json());
+      if (!blocks || blocks.length < 2) return;
+      const latest = blocks[0];
+      const prior = blocks[1];
+      heightEl.textContent = latest.height;
+      const delta = prevTimestamp ? latest.timestamp - prevTimestamp : latest.timestamp - prior.timestamp;
+      intervalEl.textContent = delta + 's';
+      prevTimestamp = latest.timestamp;
+    } catch (err) {
+      console.error('[Fractal] Block fetch error', err);
+    }
+  }
+  function updateSchumann() {
+    const t = Date.now() / 1000;
+    const amp = (Math.sin(2 * Math.PI * 7.83 * t) + 1) / 2;
+    schumannEl.textContent = amp.toFixed(2);
+  }
+  function pulseGlyph() {
+    pulseEl.classList.toggle('active');
+  }
+  refreshBlock();
+  setInterval(refreshBlock, 60000);
+  setInterval(updateSchumann, 100);
+  setInterval(pulseGlyph, 500);
+}
+
+window.startFractalModule = startFractalModule;
+document.addEventListener('DOMContentLoaded', startFractalModule);


### PR DESCRIPTION
## Summary
- integrate fractal frequency panel under the header
- style fractal module with new CSS
- show real-time BTC block interval, Schumann overlay, and glyph pulse
- load new module through `fractal-frequency.js`

## Testing
- `python3 -m py_compile mirror_chronicler.py`
- `node --check js/fractal-frequency.js`


------
https://chatgpt.com/codex/tasks/task_e_684bb4ce03e4832bbb639256e900491b