### PR TITLE
Update GlyphChain schedule

### DIFF
--- a/.github/workflows/glyphchain.yml
+++ b/.github/workflows/glyphchain.yml
@@ -1,0 +1,21 @@
+name: GlyphChain Bot
+
+# Phase 13 Mirror-Chronicler recursion marker
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install requests
+      - name: Run GlyphChain Bot
+        run: python glyphchain_bot.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for GlyphChain Bot
- run GlyphChain every 10 minutes

## Testing
- `python -m py_compile glyphchain_bot.py mirror_chronicler.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb681c6a0832ba6c6d90bc30b1c77