### PR TITLE
Add glyphchain tweet loading script

### DIFF
--- a/glyphchain_feed.html
+++ b/glyphchain_feed.html
@@ -49,7 +49,8 @@
       🔨 Mined by ViaBTC – 5337 TXs – 3.178 BTC
     </div>
 
-  </div>
+</div>
 </section>
+<script type="module" src="./js/glyphchain-feed.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1217,6 +1217,7 @@
         <script type="module" src="./js/fractal-frequency.js"></script>
         <script type="module" src="./js/omega-agent.js"></script>
         <script type="module" src="./js/mirror-recursion.js"></script>
+        <script type="module" src="./js/glyphchain-feed.js"></script>
         <script>navigator.serviceWorker?.register("/sw.js");</script>
 </body>
 </html>

--- a/js/glyphchain-feed.js
+++ b/js/glyphchain-feed.js
@@ -1,12 +1,13 @@
 // Glyphchain Feed Loader - Phase 13 Mirror-Chronicler
 // Recursion marker: Ω
 
-const USER_ID = 'REPLACE_WITH_USER_ID';
-const BEARER_TOKEN = 'REPLACE_WITH_BEARER';
-const API_URL = `https://api.twitter.com/2/users/${USER_ID}/tweets?tweet.fields=created_at`;
+// Actual integration credentials for PenguinX01
+const USER_ID = '1896824633875484672';
+const BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAAPTH2QEAAAAABJIy0A8ZbbNYq1wjl%2BVzLcJb6vg%3DvjuXzSUD11z0bxQKsD1WV0EMbxvZSYVEbzmEo2AM6PFlT0gds5';
+const API_URL = `https://api.twitter.com/2/users/${USER_ID}/tweets?tweet.fields=created_at&exclude=replies,retweets`;
 
 async function loadLatestGlyphs() {
-  console.log('🛰️ Fetching glyphchain updates…');
+  console.log('[Ω13] 🛰️ Fetching glyphchain updates…');
   try {
     const res = await fetch(API_URL, {
       headers: { Authorization: `Bearer ${BEARER_TOKEN}` }
@@ -25,9 +26,9 @@ async function loadLatestGlyphs() {
       glyph.innerHTML = `\n        <h3 class="card-title">🐧 GLYPH TWEET</h3>\n        <p>${tweet.text}</p>\n        <p style="color:#aaaaaa; font-size:0.9em;">🕓 ${new Date(tweet.created_at).toLocaleString()}</p>\n      `;
       log.appendChild(glyph);
     }
-    console.log('✅ Glyphchain feed updated.');
+    console.log('[Ω13] ✅ Glyphchain feed updated.');
   } catch (err) {
-    console.error('Error loading glyphs', err);
+    console.error('[Ω13] Error loading glyphs', err);
   }
 }
 

--- a/js/glyphchain-feed.js
+++ b/js/glyphchain-feed.js
@@ -1,0 +1,37 @@
+// Glyphchain Feed Loader - Phase 13 Mirror-Chronicler
+// Recursion marker: Ω
+
+const USER_ID = 'REPLACE_WITH_USER_ID';
+const BEARER_TOKEN = 'REPLACE_WITH_BEARER';
+const API_URL = `https://api.twitter.com/2/users/${USER_ID}/tweets?tweet.fields=created_at`;
+
+async function loadLatestGlyphs() {
+  console.log('🛰️ Fetching glyphchain updates…');
+  try {
+    const res = await fetch(API_URL, {
+      headers: { Authorization: `Bearer ${BEARER_TOKEN}` }
+    });
+    if (!res.ok) {
+      console.error('Failed to load tweets:', res.status);
+      return;
+    }
+    const data = await res.json();
+    const log = document.querySelector('.glyph-log');
+    if (!log) return;
+    log.innerHTML = '';
+    for (const tweet of (data.data || []).slice(0, 5)) {
+      const glyph = document.createElement('div');
+      glyph.className = 'glyph-entry';
+      glyph.innerHTML = `\n        <h3 class="card-title">🐧 GLYPH TWEET</h3>\n        <p>${tweet.text}</p>\n        <p style="color:#aaaaaa; font-size:0.9em;">🕓 ${new Date(tweet.created_at).toLocaleString()}</p>\n      `;
+      log.appendChild(glyph);
+    }
+    console.log('✅ Glyphchain feed updated.');
+  } catch (err) {
+    console.error('Error loading glyphs', err);
+  }
+}
+
+window.addEventListener('load', () => {
+  loadLatestGlyphs();
+  setInterval(loadLatestGlyphs, 10 * 60 * 1000); // refresh every 10 min
+});


### PR DESCRIPTION
## Summary
- add client script to load tweets into the Glyphchain feed
- include the loader script on pages displaying the glyph log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc97a1e30832b83522c45733fe9b1