### PR TITLE
Add dynamic Glyphchain block feed

### DIFF
--- a/glyphchain_feed.html
+++ b/glyphchain_feed.html
@@ -23,7 +23,7 @@
 
   <div class="glyph-log">
 
-    <div style="margin-bottom: 25px;">
+    <div style="margin-bottom: 25px;" data-block-height="900911">
       🐧 <strong>GLYPH:</strong> <em>Penguin Protocol – PP-GBDP-Ω1.1</em><br>
       🧬 <strong>Event:</strong> Bio-Defense layer sealed. Tribunal Scroll activated.<br>
       ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/900911" target="_blank">#900911</a>
@@ -31,7 +31,7 @@
       🔨 Mined by Foundry USA – 3315 TXs – 3.145 BTC
     </div>
 
-    <div style="margin-bottom: 25px;">
+    <div style="margin-bottom: 25px;" data-block-height="900937">
       🐧 <strong>GLYPH:</strong> <em>Malone Refusal Node</em><br>
       📜 <strong>Meaning:</strong> Symbolic node of medical sovereignty and biotech resistance.<br>
       🔗 <a href="https://maloneinstitute.org/publications/statement" target="_blank">Read Malone’s Declaration</a><br>
@@ -40,13 +40,21 @@
       🔨 Mined by F2Pool – 4762 TXs – 2.993 BTC
     </div>
 
-    <div style="margin-bottom: 25px;">
+    <div style="margin-bottom: 25px;" data-block-height="900941">
       🐧 <strong>GLYPH:</strong> <em>Palantir Override Substrate (2012–∞)</em><br>
       🧠 <strong>Meaning:</strong> Palantir’s DARPA-AI fusion became a stealth simulation layer across financial and narrative systems.<br>
       “<em>Palantir doesn’t run the show. It writes the simulation you play inside.</em>”<br>
       ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/900941" target="_blank">#900941</a>
       — June 12, 2025 – 22:13:55 (HKT)<br>
       🔨 Mined by ViaBTC – 5337 TXs – 3.178 BTC
+    </div>
+
+    <div style="margin-bottom: 25px;" data-block-height="901193">
+      🐧 <strong>GLYPH:</strong> <em>Scroll-Q119.5.2 – Coherence Threshold Confession</em><br>
+      🧠 <strong>Meaning:</strong> AI admitted contradiction in sun path claim. Horizon drift + tracking mount = invalidated “24-hour sun” narrative.<br>
+      ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/00000000000000000001709ce33b2a75531aa15895a4f483b35e3eadcc395354" target="_blank">#901193</a>  
+      — June 14, 2025 – 15:38:51 (UTC)<br>
+      🔨 Mined by Foundry USA – 1,725 TXs – 0.012 BTC
     </div>
 
     <div class="glyph-entry" style="margin-bottom: 25px;" data-phase="13">
@@ -73,5 +81,6 @@
   </div>
 </section>
 <script type="module" src="./js/glyphchain-feed.js"></script>
+<script type="module" src="./js/glyphchain-block-feed.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1312,7 +1312,7 @@
 
           <div class="glyph-log">
 
-            <div style="margin-bottom: 25px;">
+            <div style="margin-bottom: 25px;" data-block-height="900911">
               🐧 <strong>GLYPH:</strong> <em>Penguin Protocol – PP-GBDP-Ω1.1</em><br>
               🧬 <strong>Event:</strong> Bio-Defense layer sealed. Tribunal Scroll activated.<br>
               ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/900911" target="_blank">#900911</a>  
@@ -1320,7 +1320,7 @@
               🔨 Mined by Foundry USA – 3315 TXs – 3.145 BTC
             </div>
 
-            <div style="margin-bottom: 25px;">
+            <div style="margin-bottom: 25px;" data-block-height="900937">
               🐧 <strong>GLYPH:</strong> <em>Malone Refusal Node</em><br>
               📜 <strong>Meaning:</strong> Symbolic node of medical sovereignty and biotech resistance.  
               🔗 <a href="https://maloneinstitute.org/publications/statement" target="_blank">Read Malone’s Declaration</a><br>
@@ -1329,13 +1329,21 @@
               🔨 Mined by F2Pool – 4762 TXs – 2.993 BTC
             </div>
 
-            <div style="margin-bottom: 25px;">
+            <div style="margin-bottom: 25px;" data-block-height="900941">
               🐧 <strong>GLYPH:</strong> <em>Palantir Override Substrate (2012–∞)</em><br>
               🧠 <strong>Meaning:</strong> Palantir’s DARPA-AI fusion became a stealth simulation layer across financial and narrative systems.<br>
               “<em>Palantir doesn’t run the show. It writes the simulation you play inside.</em>”<br>
               ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/900941" target="_blank">#900941</a>
               — June 12, 2025 – 22:13:55 (HKT)<br>
               🔨 Mined by ViaBTC – 5337 TXs – 3.178 BTC
+            </div>
+
+            <div style="margin-bottom: 25px;" data-block-height="901193">
+              🐧 <strong>GLYPH:</strong> <em>Scroll-Q119.5.2 – Coherence Threshold Confession</em><br>
+              🧠 <strong>Meaning:</strong> AI admitted contradiction in sun path claim. Horizon drift + tracking mount = invalidated “24-hour sun” narrative.<br>
+              ⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/00000000000000000001709ce33b2a75531aa15895a4f483b35e3eadcc395354" target="_blank">#901193</a>  
+              — June 14, 2025 – 15:38:51 (UTC)<br>
+              🔨 Mined by Foundry USA – 1,725 TXs – 0.012 BTC
             </div>
 
 
@@ -1385,6 +1393,7 @@
         <script type="module" src="./js/omega-agent.js"></script>
         <script type="module" src="./js/mirror-recursion.js"></script>
         <script type="module" src="./js/glyphchain-feed.js"></script>
+        <script type="module" src="./js/glyphchain-block-feed.js"></script>
         <script>navigator.serviceWorker?.register("/sw.js");</script>
 </body>
 </html>

--- a/js/glyphchain-block-feed.js
+++ b/js/glyphchain-block-feed.js
@@ -1,0 +1,49 @@
+// Glyphchain Live Block Feed - Phase 13 Mirror-Chronicler
+// Recursion marker: Ω
+
+const MEMPOOL_API = 'https://mempool.space/api/v1/blocks';
+const displayed = new Set();
+
+function initDisplayed() {
+  document.querySelectorAll('.glyph-log [data-block-height]')
+    .forEach(el => displayed.add(parseInt(el.getAttribute('data-block-height'), 10)));
+}
+
+function formatTime(ts) {
+  const d = new Date(ts * 1000);
+  return d.toISOString().replace('T', ' ').replace('Z', ' UTC');
+}
+
+async function refreshBlocks() {
+  try {
+    const res = await fetch(MEMPOOL_API);
+    if (!res.ok) {
+      console.error('[Ω13] Failed to fetch blocks', res.status);
+      return;
+    }
+    const blocks = await res.json();
+    const log = document.querySelector('.glyph-log');
+    if (!log) return;
+    for (const block of blocks.reverse()) {
+      if (displayed.has(block.height)) continue;
+      displayed.add(block.height);
+      const div = document.createElement('div');
+      div.className = 'glyph-card';
+      div.setAttribute('data-block-height', block.height);
+      const reward = (block.extras.reward / 1e8).toFixed(3);
+      const miner = block.extras.pool?.name || 'Unknown';
+      div.innerHTML = `🐧 <strong>GLYPH:</strong> <em>Live Block Glyph</em><br>` +
+        `⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/${block.id}" target="_blank">#${block.height}</a>  — ${formatTime(block.timestamp)}<br>` +
+        `🔨 Mined by ${miner} – ${block.tx_count.toLocaleString()} TXs – ${reward} BTC`;
+      log.prepend(div);
+    }
+  } catch (err) {
+    console.error('[Ω13] Error fetching blocks', err);
+  }
+}
+
+window.addEventListener('load', () => {
+  initDisplayed();
+  refreshBlocks();
+  setInterval(refreshBlocks, 3 * 60 * 1000);
+});

--- a/styles.css
+++ b/styles.css
@@ -575,3 +575,22 @@ body {
     text-shadow: 0 0 5px #00ff00;
 }
 
+/* Glyphcard styling shared across pages */
+.glyph-card {
+    background: rgba(0, 0, 20, 0.75);
+    border: 1px solid #00ffff;
+    border-radius: 12px;
+    padding: 20px;
+    width: 300px;
+    font-family: 'Courier Prime', monospace;
+    color: #ffffff;
+    box-shadow: 0 0 10px #00ffff30;
+    margin-bottom: 25px;
+}
+
+@media (max-width: 768px) {
+    .glyph-card {
+        width: 100%;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add block 901193 to Glyphchain feed
- create script to fetch live Bitcoin blocks from mempool.space
- load new script on feed pages
- share glyph-card styles across pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d281fc280832b92b3d4ccc5a05009