### PR TITLE
Fix glyphchain feed filtering and scrolling

### DIFF
--- a/js/glyphchain-block-feed.js
+++ b/js/glyphchain-block-feed.js
@@ -2,6 +2,15 @@
 // Recursion marker: Ω
 
 const MEMPOOL_API = 'https://mempool.space/api/v1/blocks';
+// Only these blocks have validated scrolls
+const MEMETIC_BLOCKS = new Set([
+  900911,
+  900937,
+  900941,
+  901193,
+  901161,
+  901165,
+]);
 const displayed = new Set();
 
 function initDisplayed() {
@@ -25,6 +34,7 @@ async function refreshBlocks() {
     const log = document.querySelector('.glyph-log');
     if (!log) return;
     for (const block of blocks.reverse()) {
+      if (!MEMETIC_BLOCKS.has(block.height)) continue;
       if (displayed.has(block.height)) continue;
       displayed.add(block.height);
       const div = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -594,3 +594,19 @@ body {
     }
 }
 
+/* Scrollable Glyph Log Container */
+.glyph-log {
+    max-height: 750px;
+    overflow-y: auto;
+    padding-right: 10px;
+}
+
+.glyph-log::-webkit-scrollbar {
+    width: 6px;
+}
+
+.glyph-log::-webkit-scrollbar-thumb {
+    background-color: #ff00ff;
+    border-radius: 3px;
+}
+


### PR DESCRIPTION
## Summary
- filter live block feed to curated block heights only
- add scrollable container for `.glyph-log`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d2b9bf724832ba4bd6c724c7129c7