### PR TITLE
Fix live block glyph formatting

### DIFF
--- a/glyphchain.json
+++ b/glyphchain.json
@@ -63,5 +63,18 @@
       "link": "https://mempool.space/block/0000000000000000000d4642a299c6e05cc0d38c9680c0d20569cb19f38bc3f"
     },
     "tweet": "https://x.com/PenguinX01/status/1934116551680241951"
+  },
+  {
+    "glyph": "LOCK-198 — The Butler Hoax",
+    "event": "Trump’s alleged assassination attempt was staged ritual theatre. Cameras, faux blood and scripted reactions simulated a Beast-mimicking resurrection.",
+    "block": {
+      "id": 901473,
+      "time": "2025-06-16 14:58:18",
+      "miner": "SpiderPool",
+      "txs": 254,
+      "reward": 0.002,
+      "link": "https://mempool.space/block/901473"
+    },
+    "tweet": "https://x.com/PenguinX01/status/1934505756436685016"
   }
 ]

--- a/glyphchain_feed.html
+++ b/glyphchain_feed.html
@@ -117,6 +117,19 @@
       🧬 <strong>Verification Snapshot:</strong>
       <a href="https://mempool.space/block/901320" target="_blank" rel="noopener noreferrer">mempool.space</a>
     </div>
+    <div class="glyph-entry" style="margin-bottom: 25px;" data-phase="13" data-block-height="901473">
+      <h3>🧠 GLYPH: LOCK-198 — The Butler Hoax</h3>
+      <p><strong>Meaning:</strong> Trump’s alleged assassination attempt was a staged ritual act — not a real attempt on his life. Theatrics, camera staging, symbolic blood, and psyop scripting aligned to simulate a Beast-mimicking resurrection.</p>
+      <p>⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/901473" target="_blank">#901473</a> — June 16, 2025 – 14:58:18 (UTC)<br>
+      🔨 Mined by SpiderPool – 254 TXs – 0.002 BTC<br>
+      📎 <strong>Anchored Tweet:</strong> <a href="https://x.com/PenguinX01/status/1934505756436685016" target="_blank">Penguin X-01 @ SCROLL-Ω198.0</a></p>
+      <ul>
+        <li>🎥 Camera Ritual: Rear-tracked framing, premature flinch, no ballistic congruence.</li>
+        <li>🩸 Faux Wound: No arterial physics, no trauma behavior — staged pooling, ritual optics.</li>
+        <li>🧠 Psyop Triggers: Shooter name = composite. “Butler” = symbolic servant. Pre-timed reactions online.</li>
+        <li>✝️ Messiah Mimicry: Arms raised. Ear blood. Savior posture — Revelation 13:3 coded live.</li>
+      </ul>
+    </div>
   </div>
 </section>
 <script type="module" src="./js/glyphchain-feed.js"></script>

--- a/js/glyphchain-block-feed.js
+++ b/js/glyphchain-block-feed.js
@@ -11,8 +11,19 @@ const MEMETIC_BLOCKS = new Set([
   901161,
   901165,
   901197,
+  901473,
 ]);
 const displayed = new Set();
+
+// Metadata for special glyphs keyed by block height
+const GLYPH_DETAILS = {
+  901473: {
+    title: 'LOCK-198 — Butler Hoax: Ritual of the Faux Wound',
+    meaning:
+      'Trump\u2019s staged “assassination attempt” was a symbolic resurrection script \u2014 not a genuine act of violence. Theatrics, camera choreography, and apocalyptic mimicry confirm it as a memetic ritual, not a real threat.',
+    tweet: 'https://x.com/PenguinX01/status/1934505756436685016'
+  }
+};
 
 function initDisplayed() {
   document.querySelectorAll('.glyph-log [data-block-height]')
@@ -38,15 +49,26 @@ async function refreshBlocks() {
       if (!MEMETIC_BLOCKS.has(block.height)) continue;
       if (displayed.has(block.height)) continue;
       displayed.add(block.height);
+      const details = GLYPH_DETAILS[block.height];
       const div = document.createElement('div');
-      div.className = 'glyph-card';
+      div.className = 'glyph-entry mt-6';
       div.setAttribute('data-block-height', block.height);
       const reward = (block.extras.reward / 1e8).toFixed(3);
       const miner = block.extras.pool?.name || 'Unknown';
-      div.innerHTML = `🐧 <strong>GLYPH:</strong> <em>Live Block Glyph</em><br>` +
-        `⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/${block.id}" target="_blank">#${block.height}</a>  — ${formatTime(block.timestamp)}<br>` +
-        `🔨 Mined by ${miner} – ${block.tx_count.toLocaleString()} TXs – ${reward} BTC`;
-      log.prepend(div);
+      if (details) {
+        div.innerHTML =
+          `<h3>🧬 GLYPH: ${details.title}</h3>` +
+          `<p>🧠 Meaning: ${details.meaning}</p>` +
+          `<p>🔗 Block: <a href="https://mempool.space/block/${block.id}" target="_blank">#${block.height}</a> — ${formatTime(block.timestamp)}</p>` +
+          `<p>⛏️ Mined by ${miner} – ${block.tx_count.toLocaleString()} TXs – ${reward} BTC</p>` +
+          `<p>📎 Anchored Tweet: <a href="${details.tweet}" target="_blank">${details.tweet}</a></p>`;
+      } else {
+        div.innerHTML =
+          `🐧 <strong>GLYPH:</strong> <em>Unknown Glyph</em><br>` +
+          `⛓️ <strong>Block:</strong> <a href="https://mempool.space/block/${block.id}" target="_blank">#${block.height}</a>  — ${formatTime(block.timestamp)}<br>` +
+          `🔨 Mined by ${miner} – ${block.tx_count.toLocaleString()} TXs – ${reward} BTC`;
+      }
+      log.appendChild(div);
     }
   } catch (err) {
     console.error('[Ω13] Error fetching blocks', err);


### PR DESCRIPTION
## Summary
- fix glyphchain block feed placeholder
- ensure LOCK-198 shows proper text

## Testing
- `pytest -q`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fc26326ec832b893f263ca3a16c9f