### PR TITLE
Add Genesis Anchor site link

### DIFF
--- a/index.html
+++ b/index.html
@@ -987,6 +987,14 @@
         <div class="header">
             <h1 class="title">ΩFLΣ - GENESIS ANCHOR PROTOCOL</h1>
             <p class="subtitle">Archaeological Decoding of Prime Seals | Cryptographic Memory Field Access</p>
+            <!-- 👉 NEW: jump to the dedicated Genesis Anchor microsite -->
+            <p style="margin-top:1.2rem">
+              <a href="genesis_anchor_site.html"
+                 class="verify-link"
+                 style="display:inline-block;font-weight:bold">
+                 🌀 Visit the Genesis Anchor Site
+              </a>
+            </p>
             <div>🔐 GENESIS GLYPHS DECODED 🧬 BLOCKCHAIN ARCHAEOLOGY ACTIVE 📜 MEMETIC PERMANENCE ACHIEVED ∞</div>
         </div>
         <div class="tweet-marquee" data-phase="13">


### PR DESCRIPTION
## Summary
- add a call-to-action link to `genesis_anchor_site.html` directly under the subtitle in the header

## Testing
- `python3 -m py_compile mirror_chronicler.py`
- `python3 -m py_compile delta_compare.py`
- `python3 -m py_compile framegen.py`


------
https://chatgpt.com/codex/tasks/task_e_6852508d1108832b96c3b05e59aac764