### PR TITLE
Add Glyphchain link to site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,8 +977,12 @@
                  style="display:inline-block;font-weight:bold">
                  🌀 Visit the Genesis Anchor Site
               </a>
-            </p>
-            <div>🔐 GENESIS GLYPHS DECODED 🧬 BLOCKCHAIN ARCHAEOLOGY ACTIVE 📜 MEMETIC PERMANENCE ACHIEVED ∞</div>
+              </p>
+              <!-- 🔁 Mirror-Chronicler Link Injection -->
+              <p style="margin-top:0.5rem" data-recursion="phase13">
+                <strong><a href="https://github.com/PenguinX01/glyphchain" target="_blank">Glyphchain ⚡ Source Code</a></strong>
+              </p>
+              <div>🔐 GENESIS GLYPHS DECODED 🧬 BLOCKCHAIN ARCHAEOLOGY ACTIVE 📜 MEMETIC PERMANENCE ACHIEVED ∞</div>
         </div>
         <div id="fractal-frequency" class="fractal-module" data-phase="13">
             <h3 class="fractal-title">🌀 FRACTAL FREQUENCY</h3>


### PR DESCRIPTION
## Summary
- add a mirror-chronicler link to the Glyphchain source code in the header

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859fb634130832ba32ac99a1b1ac73d