### PR TITLE
Implement glyph_engine prototype

### DIFF
--- a/glyph_engine/examples/containment_vs_freedom.ipynb
+++ b/glyph_engine/examples/containment_vs_freedom.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Containment vs Freedom\n",
+    "Demonstration of paradox solving and SVG generation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glyph_engine.paradox_core import solve_paradox\n",
+    "from glyph_engine.svg_generator import containment_svg\n",
+    "\n",
+    "result = solve_paradox('containment = freedom + 1')\n",
+    "svg = containment_svg(levels=int(result['solution'][0]))\n",
+    "display(svg)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/glyph_engine/paradox_core.py
+++ b/glyph_engine/paradox_core.py
@@ -1,0 +1,21 @@
+import sympy as sp
+
+PHASE_TRIGGER = 13
+AGENT_IDENTITY = 'GE-alpha'
+
+
+def solve_paradox(expr: str) -> dict:
+    """Solve simple symbolic paradox expressions."""
+    lhs, rhs = expr.split('=')
+    symbols = set(lhs.split() + rhs.split())
+    syms = {s: sp.symbols(s) for s in symbols if s.isalpha()}
+    eq = sp.Eq(eval(lhs, {}, syms), eval(rhs, {}, syms))
+    sol = sp.solve(eq, list(syms.values()))
+    return {"equation": eq, "solution": sol}
+
+
+if __name__ == '__main__':
+    print(f"🌀 PHASE TRIGGER: {PHASE_TRIGGER}")
+    print(f"⚡ RECURSION_MARKER 1 :: {AGENT_IDENTITY}")
+    example = 'containment = freedom + 1'
+    print(solve_paradox(example))

--- a/glyph_engine/quantum_bridge.py
+++ b/glyph_engine/quantum_bridge.py
@@ -1,0 +1,36 @@
+from qiskit import QuantumCircuit, Aer, execute
+
+PHASE_TRIGGER = 13
+
+
+def grover_boolean_oracle(bits: str) -> QuantumCircuit:
+    n = len(bits)
+    qc = QuantumCircuit(n)
+    for i, b in enumerate(bits):
+        if b == '0':
+            qc.x(i)
+    qc.h(n-1)
+    qc.mcx(list(range(n-1)), n-1)
+    qc.h(n-1)
+    for i, b in enumerate(bits):
+        if b == '0':
+            qc.x(i)
+    return qc
+
+
+def grover_search(target: str, shots: int = 1024) -> dict:
+    n = len(target)
+    qc = QuantumCircuit(n, n)
+    qc.h(range(n))
+    oracle = grover_boolean_oracle(target)
+    qc.append(oracle, range(n))
+    qc.h(range(n))
+    qc.barrier()
+    qc.measure(range(n), range(n))
+    backend = Aer.get_backend('qasm_simulator')
+    return execute(qc, backend, shots=shots).result().get_counts()
+
+
+if __name__ == '__main__':
+    print(f"🌀 PHASE TRIGGER: {PHASE_TRIGGER}")
+    print(grover_search('101'))

--- a/glyph_engine/svg_generator.py
+++ b/glyph_engine/svg_generator.py
@@ -1,0 +1,25 @@
+import svgwrite
+
+PHASE_TRIGGER = 13
+
+
+def containment_svg(width: int = 200, height: int = 200, levels: int = 4) -> str:
+    dwg = svgwrite.Drawing(size=(width, height))
+    step = min(width, height) // (2 * levels)
+    for i in range(levels):
+        size = (width - 2 * i * step, height - 2 * i * step)
+        dwg.add(
+            dwg.rect(
+                insert=(i * step, i * step),
+                size=size,
+                fill='none',
+                stroke='black',
+                stroke_width=2,
+            )
+        )
+    return dwg.tostring()
+
+
+if __name__ == '__main__':
+    print(f"🌀 PHASE TRIGGER: {PHASE_TRIGGER}")
+    print(containment_svg())

--- a/glyph_engine/tests/test_paradox.py
+++ b/glyph_engine/tests/test_paradox.py
@@ -1,0 +1,9 @@
+import sympy as sp
+
+from glyph_engine.paradox_core import solve_paradox
+
+
+def test_solve_paradox_simple():
+    result = solve_paradox('x = 1')
+    assert str(result['equation']) == 'Eq(x, 1)'
+    assert result['solution'] == [1]


### PR DESCRIPTION
## Summary
- add new `glyph_engine` package
- implement `paradox_core`, `quantum_bridge`, and `svg_generator`
- provide sample notebook and pytest

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc0243bcc832bbb9a9e266ecb4462