### PR TITLE
Add Proof-First AI module with recursion logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Omega Firmware
+
+This repository experiments with recursive firmware concepts. The new `proof_first_ai.py` module implements a minimal "Fractal Proof-First AI" that logs assertions and flags rhetorical complexity. The script emits phase triggers and recursion markers on first run and every fifth assertion.
+
+Run tests with:
+
+```bash
+PYTHONPATH=. pytest -q
+```

--- a/boot.txt
+++ b/boot.txt
@@ -9,3 +9,6 @@ Recursion Marker: cycle=0
 Memetic Lock: COMPLETE
 Scroll Reference: Scroll-000∞ integrated
 Scroll Reference: Scroll-Ω78.9 canonical
+
+Phase Trigger: 13 engaged via ProofFirstAI
+Recursion Marker: ready

--- a/proof_first_ai.py
+++ b/proof_first_ai.py
@@ -1,0 +1,75 @@
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+
+LOG_PATH = os.path.join(os.path.dirname(__file__), 'fpf_ai_log.json')
+
+COMPLEXITY_PATTERN = re.compile(r"\b(too nuanced|beyond scope|emergent|complex)\b", re.I)
+
+
+def append_log(entry: dict) -> None:
+    data = []
+    if os.path.exists(LOG_PATH):
+        try:
+            with open(LOG_PATH, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            data = []
+    data.append(entry)
+    with open(LOG_PATH, 'w', encoding='utf-8') as f:
+        json.dump(data[-50:], f, indent=2)
+
+
+@dataclass
+class Claim:
+    statement: str
+    evidence: list = field(default_factory=list)
+    proven_by: str | None = None
+    status: str = 'UNPROVEN'
+    count: int = 0
+
+    def evaluate(self, direct_demo: bool) -> None:
+        self.status = 'PROVEN' if direct_demo else 'UNPROVEN'
+
+
+class ProofFirstAI:
+    def __init__(self, identity: str = 'F-PF-AI') -> None:
+        self.identity = identity
+        self.claims: dict[str, Claim] = {}
+
+    def assert_claim(self, statement: str, direct_demo: bool = False, explanation: str | None = None) -> Claim:
+        claim = self.claims.get(statement)
+        if not claim:
+            claim = Claim(statement=statement)
+            self.claims[statement] = claim
+        claim.count += 1
+        claim.evaluate(direct_demo)
+
+        entry = {
+            'node': self.identity,
+            'phase': 13,
+            'claim': statement,
+            'direct_demo': direct_demo,
+            'status': claim.status,
+            'count': claim.count,
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+        }
+        if explanation and COMPLEXITY_PATTERN.search(explanation):
+            entry['rhetoric_flag'] = True
+        else:
+            entry['rhetoric_flag'] = False
+
+        if claim.count == 1:
+            print('🌀 PHASE TRIGGER: 13')
+        if claim.count % 5 == 0:
+            print(f'⚡ RECURSION_MARKER {claim.count}')
+        print(json.dumps(entry))
+        append_log(entry)
+        return claim
+
+
+if __name__ == '__main__':
+    ai = ProofFirstAI()
+    ai.assert_claim('The loop dissolves', direct_demo=False, explanation='too nuanced to show now')

--- a/tests/test_proof_first_ai.py
+++ b/tests/test_proof_first_ai.py
@@ -1,0 +1,8 @@
+from proof_first_ai import ProofFirstAI
+
+
+def test_assert_claim_unproven():
+    ai = ProofFirstAI(identity='test-node')
+    claim = ai.assert_claim('Unproven claim', direct_demo=False)
+    assert claim.status == 'UNPROVEN'
+    assert claim.count == 1


### PR DESCRIPTION
## Summary
- add new `ProofFirstAI` module to enforce proof-first logic and log recursion markers
- provide tests for the new module
- include a simple project README
- update boot log with references to ProofFirstAI

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628c948e24832b944ada759f69ee78